### PR TITLE
CloudFormation ELB template retain logs bucket on delete

### DIFF
--- a/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_trinity.json
+++ b/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_trinity.json
@@ -37,7 +37,8 @@
 
   "Resources" : {
     "Bucket": {
-      "Type": "AWS::S3::Bucket"
+      "Type": "AWS::S3::Bucket",
+      "DeletionPolicy": "Retain"
     },
 
     "BucketPolicy": {


### PR DESCRIPTION
This test now writes ELB logs to the bucket so deletion fails without retain causing a test failure.