### PR TITLE
ELB route53 load balancer alias target tests

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/TestCFTemplatesFull.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestCFTemplatesFull.groovy
@@ -315,6 +315,10 @@ class TestCFTemplatesFull {
       }
       Assert.assertNotNull('Expected response from load balancer', foundResponse )
 
+      N4j.print( 'Verifying route53 alias for elb' )
+      String balancerIpFromAlias = lookup( 'elb.trinity.eucalyptus.internal', dnsHosts )
+      Assert.assertEquals( 'ELB ip from alias', balancerIp, balancerIpFromAlias )
+
       N4j.print( 'Verifying load balancer cookie present' )
       String setCookieHeader = url.openConnection( ).getHeaderField( 'Set-Cookie' )
       N4j.print( "Set-Cookie: ${setCookieHeader}" )

--- a/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_trinity.json
+++ b/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_trinity.json
@@ -216,6 +216,27 @@
             "SourceSecurityGroupName" : {"Fn::GetAtt" : ["ElasticLoadBalancer", "SourceSecurityGroup.GroupName"]}
           } ]
       }
+    },
+
+    "HostedZone" : {
+      "Type" : "AWS::Route53::HostedZone",
+      "Properties" : {
+        "Name" : "trinity.eucalyptus.internal"
+      }
+    },
+
+    "RecordSet" : {
+      "Type" : "AWS::Route53::RecordSet",
+      "Properties" : {
+        "HostedZoneId" : {"Ref" : "HostedZone"},
+        "Name" : "elb.trinity.eucalyptus.internal",
+        "Type" : "A",
+        "AliasTarget" : {
+          "DNSName": {"Fn::GetAtt" : ["ElasticLoadBalancer", "DNSName"]},
+          "EvaluateTargetHealth": false,
+          "HostedZoneId": {"Fn::GetAtt" : ["ElasticLoadBalancer", "CanonicalHostedZoneNameID"]}
+        }
+      }
     }
   },
 


### PR DESCRIPTION
N4J tests covering elb route53 hosted zone alias targets.

The cloudformation trinity template test is updated to create route53 resources with the dns alias being verified post stack create. The elb ec2 test is updated to verify that the expected canonical hosted zone details are present in describe load balancer responses.

Provides test coverage for corymbia/eucalyptus#184