### PR TITLE
CloudFormation full test suite specify zone

### DIFF
--- a/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_trinity.json
+++ b/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_trinity.json
@@ -63,7 +63,7 @@
     "WebServerGroup" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
-        "AvailabilityZones" : { "Fn::GetAZs" : ""},
+        "AvailabilityZones" : [ { "Fn::Select" : [ "0", { "Fn::GetAZs" : "" } ] } ],
         "LaunchConfigurationName" : { "Ref" : "LaunchConfig" },
         "MinSize" : "1",
         "MaxSize" : "3",
@@ -176,7 +176,7 @@
           "Enabled" : true,
           "S3BucketName" : { "Ref" : "Bucket" }
         },
-        "AvailabilityZones" : { "Fn::GetAZs" : "" },
+        "AvailabilityZones" : [ { "Fn::Select" : [ "0", { "Fn::GetAZs" : "" } ] } ],
         "CrossZone" : "true",
         "HealthCheck" : {
           "Target" : "HTTP:80/",


### PR DESCRIPTION
The cloudformation full test suite now uses a template that picks a single zone when there are multiple availability zones.

The demo is that the test passes on a multiple zone deployment with the fix in place but fails without it due to ip address check failures (with more than one zone there will be multiple load balancer ip addresses)