### PR TITLE
EC2 EBS image registration output piped via cat

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2EbsImageRegistration.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2EbsImageRegistration.groovy
@@ -91,7 +91,7 @@ class TestEC2EbsImageRegistration {
             sleep 10
           done
           echo "Writing to device /dev/\${DEVICE_NAME}"
-          curl ${imageLocation} | tar -xzOf - CentOS-7-x86_64-GenericCloud-1801-01.raw > /dev/\${DEVICE_NAME}
+          curl -sS ${imageLocation} | tar -xzOf - CentOS-7-x86_64-GenericCloud-1801-01.raw | cat > /dev/\${DEVICE_NAME}
           """.stripIndent( ).trim( )
       String instanceId = ec2.runInstances(new RunInstancesRequest(
           minCount: 1,


### PR DESCRIPTION
Write image to volume via `cat`.

Test: /job/eucalyptus-5-qa-suite/211/