### PR TITLE
EC2 IAM condition keys test increase instance running wait

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2IAMConditionKeys.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2IAMConditionKeys.groovy
@@ -2928,7 +2928,7 @@ class TestEC2IAMConditionKeys {
 
     // Wait until running
     print( 'Waiting for instances to be running...' )
-    waitForInstances( accountEc2, TimeUnit.MINUTES.toMillis( 2 ) )
+    waitForInstances( accountEc2, TimeUnit.MINUTES.toMillis( 5 ) )
 
     accountEc2.with {
       print( "Describing instance ${instanceId} to check tags" )
@@ -3259,7 +3259,7 @@ class TestEC2IAMConditionKeys {
 
     // Wait until running
     print( 'Waiting for instances to be running...' )
-    waitForInstances( accountEc2, TimeUnit.MINUTES.toMillis( 2 ) )
+    waitForInstances( accountEc2, TimeUnit.MINUTES.toMillis( 5 ) )
 
     accountEc2.with {
       print( "Describing instance ${instanceId} to check tags" )
@@ -3460,7 +3460,7 @@ class TestEC2IAMConditionKeys {
 
     // Wait until running
     print( 'Waiting for instances to be running...' )
-    waitForInstances( accountEc2, TimeUnit.MINUTES.toMillis( 2 ) )
+    waitForInstances( accountEc2, TimeUnit.MINUTES.toMillis( 5 ) )
 
     accountEc2.with {
       print( "Describing instance ${instanceId} to check tags" )


### PR DESCRIPTION
Use 5 minute wait for all run instance use in ec2 iam condition key test.