### PR TITLE
Use azure artifacts and maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,13 @@ targetCompatibility = 1.8
 sourceCompatibility = 1.8
 
 repositories {
-    jcenter( )
+    maven {
+      url 'https://pkgs.dev.azure.com/sjones4/eucalyptus/_packaging/maven/maven/v1'
+      content {
+        includeGroup('com.github.sjones4')
+      }
+    }
+    mavenCentral( )
 }
 
 sourceSets {
@@ -63,19 +69,19 @@ Run unit tests. To run quick tests use: ./gradlew -Dclcip=CLC_IP_ADDR test \
 }
 
 dependencies {
-    compile 'com.amazonaws:aws-java-sdk-autoscaling:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-cloudformation:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-cloudwatch:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-core:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-ec2:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-elasticloadbalancing:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-iam:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-route53:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-s3:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-simpleworkflow:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-sqs:[1.11.420,1.12]'
-    compile 'com.amazonaws:aws-java-sdk-sts:[1.11.420,1.12]'
-    compile 'com.github.sjones4:you-are-sdk:[1.2.2,1.3]'
+    compile 'com.amazonaws:aws-java-sdk-autoscaling:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-cloudformation:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-cloudwatch:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-core:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-ec2:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-elasticloadbalancing:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-iam:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-route53:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-s3:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-simpleworkflow:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-sqs:[1.11.420,1.12)'
+    compile 'com.amazonaws:aws-java-sdk-sts:[1.11.420,1.12)'
+    compile 'com.github.sjones4:you-are-sdk:[1.2.2,1.3)'
     compile 'com.google.guava:guava:24.0-jre'
     compile 'com.jcraft:jsch:0.1.54'
     compile 'junit:junit:4.+'


### PR DESCRIPTION
Use azure artifacts hosted sdk rather than bintray/jcenter.

> Repositories Hosted on Bintray 
Your repositories for module types including Docker, Maven (Java), Npm, NuGet, RPM, Vagrant, and Generic will need to be migrated off of Bintray service on or before May 1st to avoid any disruption in service.

Update dependencies to use exclusive version ranges.