### PR TITLE
CloudFormation vpc network acls template wait for network interface

### DIFF
--- a/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_vpc_nacls.yaml
+++ b/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_vpc_nacls.yaml
@@ -635,6 +635,7 @@ Resources:
                COND_DATA="${!COND_DATA}, TEST101"
                COND_REASON="complete"
           runcmd:
+           - while ! ip link show eth1 ; do sleep 15 ; done
            - ip link set dev eth1 up
            - ip address add 10.13.202.202/24 dev eth1
            - ip route add 10.13.128.0/17 via 10.13.202.1 dev eth1 src 10.13.202.202
@@ -716,6 +717,7 @@ Resources:
                COND_DATA="${!COND_DATA}, TEST101"
                COND_REASON="complete"
           runcmd:
+           - while ! ip link show eth1 ; do sleep 15 ; done
            - ip link set dev eth1 up
            - ip address add 10.13.204.204/24 dev eth1
            - ip route add 10.13.128.0/17 via 10.13.204.1 dev eth1 src 10.13.204.204


### PR DESCRIPTION
The cloudformation vpc network acls test template is updated to wait for the `eth1` network interface to be available.

The test could fail due to timing of the network interface attachment. The test can now run successfully if the network interface is attached after cloud config commands are run.