### PR TITLE
CloudFormation vpc metadata template ensure gateway attached

### DIFF
--- a/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_vpc_meta.json
+++ b/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_vpc_meta.json
@@ -177,6 +177,7 @@
     },
     "Route": {
       "Type": "AWS::EC2::Route",
+      "DependsOn": "AttachInternetGateway",
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
         "GatewayId": {

--- a/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_vpc_meta_vpc_platform.json
+++ b/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_vpc_meta_vpc_platform.json
@@ -213,6 +213,7 @@
     },
     "Route": {
       "Type": "AWS::EC2::Route",
+      "DependsOn": "AttachInternetGateway",
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
         "GatewayId": {


### PR DESCRIPTION
The cloudformation vpc metadata test template is updated to add a dependency between `Route` and `AttachInternetGateway`.

Adding a route requires that the internet gateway is already attached to the vpc, without the explicit dependency the test would fail intermittently.